### PR TITLE
Added support for Evergreen language filter

### DIFF
--- a/Apps/NotepadPlusPlus/App.json
+++ b/Apps/NotepadPlusPlus/App.json
@@ -21,7 +21,7 @@
         "DeviceRestartBehavior": "suppress"
     },
     "RequirementRule": {
-        "MinimumSupportedWindowsRelease": "21H2",
+        "MinimumSupportedWindowsRelease": "W10_21H2",
         "Architecture": "x64"
     },
     "CustomRequirementRule": [

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # IntuneAppFactory
-IntuneAppFactory is a set of PowerShell scripts used in an Azure DevOps Pipeline to detect, download, package and publish onboarded applications as a Win32 application to Intune, to ensure the latest version of onboarded applications are available in Intune.
+IntuneAppFactory is a set of PowerShell scripts used in an Azure DevOps Pipeline to detect, download, package and publish onboarded applications as a Win32 application to Intune, to ensure the latest version of onboarded applications are available in Intune."# IntuneAppFactoryConfiguration" 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # IntuneAppFactory
 IntuneAppFactory is a set of PowerShell scripts used in an Azure DevOps Pipeline to detect, download, package and publish onboarded applications as a Win32 application to Intune, to ensure the latest version of onboarded applications are available in Intune."# IntuneAppFactoryConfiguration" 
+"# IntuneAppFactoryConfiguration" 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,2 @@
 # IntuneAppFactory
-IntuneAppFactory is a set of PowerShell scripts used in an Azure DevOps Pipeline to detect, download, package and publish onboarded applications as a Win32 application to Intune, to ensure the latest version of onboarded applications are available in Intune."# IntuneAppFactoryConfiguration" 
-"# IntuneAppFactoryConfiguration" 
+IntuneAppFactory is a set of PowerShell scripts used in an Azure DevOps Pipeline to detect, download, package and publish onboarded applications as a Win32 application to Intune, to ensure the latest version of onboarded applications are available in Intune.

--- a/Scripts/Test-AppList.ps1
+++ b/Scripts/Test-AppList.ps1
@@ -69,6 +69,9 @@ Process {
         if ($FilterOptions.InstallerType) {
             $FilterList.Add("`$PSItem.InstallerType -eq ""$($FilterOptions.InstallerType)""") | Out-Null
         }
+        if ($FilterOptions.Language) {
+            $FilterList.Add("`$PSItem.Language -eq ""$($FilterOptions.Language)""") | Out-Null
+        }
     
         # Construct script block from filter list array
         $FilterExpression = [scriptblock]::Create(($FilterList -join " -and "))

--- a/Scripts/Test-AppList.ps1
+++ b/Scripts/Test-AppList.ps1
@@ -72,6 +72,9 @@ Process {
         if ($FilterOptions.Language) {
             $FilterList.Add("`$PSItem.Language -eq ""$($FilterOptions.Language)""") | Out-Null
         }
+        if ($FilterOptions.Edition ) {
+            $FilterList.Add("`$PSItem.Edition -eq ""$($FilterOptions.Edition )""") | Out-Null
+        }
     
         # Construct script block from filter list array
         $FilterExpression = [scriptblock]::Create(($FilterList -join " -and "))


### PR DESCRIPTION
Some Evergreen apps (like FoxitReader) don't allow for filtering on the currently available options. Therefor I have added support to filter on the Language.

Of possible this should be updated in the documentation (https://msendpointmgr.com/intune-app-factory/#evergreen) as well. Currently it lists 4 filters (architecture, platform, channel and type). Language and InstallerType (which is already available in the Test-AppList.ps1 script) should be added.