### PR TITLE
Update Install-Modules.ps1

### DIFF
--- a/Scripts/Install-Modules.ps1
+++ b/Scripts/Install-Modules.ps1
@@ -5,5 +5,5 @@ $PackageProvider = Install-PackageProvider -Name "NuGet" -Force
 $Modules = @("Evergreen", "IntuneWin32App", "MSGraphRequest", "Az.Storage", "Az.Resources")
 foreach ($Module in $Modules) {
     Write-Output -InputObject "Attempting to install the following module: $($Module)"
-    Install-Module -Name $Module -Force -Confirm:$false
+    Install-Module -Name $Module -Force -Confirm:$false -AllowClobber
 }


### PR DESCRIPTION
The following commands are already available on this system:'Test-AccessToken'. This module 'MSGraphRequest' may override the  existing commands. If you still want to install this module 'MSGraphRequest', use -AllowClobber parameter.

Extract from https://learn.microsoft.com/en-us/powershell/module/powershellget/install-module?view=powershellget-3.x#-allowclobber

-AllowClobber
Overrides warning messages about installation conflicts about existing commands on a computer. Overwrites existing commands that have the same name as commands being installed by a module. AllowClobber and Force can be used together in an Install-Module command.

The proxy cmdlet transform the value of this parameter to the NoClobber parameter of the Install-PSResource cmdlet.