### PR TITLE
Update New-Win32App.ps1

### DIFF
--- a/Scripts/New-Win32App.ps1
+++ b/Scripts/New-Win32App.ps1
@@ -170,6 +170,7 @@ Process {
 
             # Create required .intunewin package from source folder
             Write-Output -InputObject "Creating .intunewin package file from source folder"
+            Invoke-WebRequest -URI "https://github.com/microsoft/Microsoft-Win32-Content-Prep-Tool/raw/1a00a2a786de646c5fc46d6e1b79988c636e764e/IntuneWinAppUtil.exe" -outfile "$env:TEMP\IntuneWinAppUtil.exe"
             $IntuneAppPackage = New-IntuneWin32AppPackage -SourceFolder $SourceFolder -SetupFile $AppData.PackageInformation.SetupFile -OutputFolder $OutputFolder
 
             # Create default requirement rule

--- a/Scripts/New-Win32App.ps1
+++ b/Scripts/New-Win32App.ps1
@@ -170,7 +170,7 @@ Process {
 
             # Create required .intunewin package from source folder
             Write-Output -InputObject "Creating .intunewin package file from source folder"
-            Invoke-WebRequest -URI "https://github.com/microsoft/Microsoft-Win32-Content-Prep-Tool/raw/1a00a2a786de646c5fc46d6e1b79988c636e764e/IntuneWinAppUtil.exe" -outfile "$env:TEMP\IntuneWinAppUtil.exe"
+            Invoke-WebRequest -URI "https://github.com/microsoft/Microsoft-Win32-Content-Prep-Tool/raw/master/IntuneWinAppUtil.exe" -outfile "$env:TEMP\IntuneWinAppUtil.exe"
             $IntuneAppPackage = New-IntuneWin32AppPackage -SourceFolder $SourceFolder -SetupFile $AppData.PackageInformation.SetupFile -OutputFolder $OutputFolder
 
             # Create default requirement rule

--- a/Scripts/New-Win32App.ps1
+++ b/Scripts/New-Win32App.ps1
@@ -170,7 +170,7 @@ Process {
 
             # Create required .intunewin package from source folder
             Write-Output -InputObject "Creating .intunewin package file from source folder"
-            Invoke-WebRequest -URI "https://github.com/microsoft/Microsoft-Win32-Content-Prep-Tool/raw/master/IntuneWinAppUtil.exe" -outfile "$env:TEMP\IntuneWinAppUtil.exe"
+            Invoke-WebRequest -URI "https://github.com/microsoft/Microsoft-Win32-Content-Prep-Tool/raw/1a00a2a786de646c5fc46d6e1b79988c636e764e/IntuneWinAppUtil.exe" -outfile "$env:TEMP\IntuneWinAppUtil.exe"
             $IntuneAppPackage = New-IntuneWin32AppPackage -SourceFolder $SourceFolder -SetupFile $AppData.PackageInformation.SetupFile -OutputFolder $OutputFolder
 
             # Create default requirement rule


### PR DESCRIPTION
C:\ADOAgent\_work\1\s\Scripts\New-Win32App.ps1 : Cannot validate argument on parameter 'FilePath'. Cannot bind  argument to parameter 'Path' because it is an empty string.

"Temporary" workaround, makes it so that the intunewinapputil.exe is always found since it is in $env. it is not a good long term solution but at least it gets everything working again. I will need someone with a better grasp to fix this in a more long term manner.