### PR TITLE
ProductVersion ist needed for MSI ProductCode Builds

### DIFF
--- a/Templates/Application/App.json
+++ b/Templates/Application/App.json
@@ -71,7 +71,8 @@
         {
             "Type": "MSI",
             "ProductCode": "<replaced_by_pipeline>",
-            "ProductVersionOperator": "notConfigured"
+            "ProductVersionOperator": "notConfigured",
+            "ProductVersion": "<replaced_by_pipeline>"
         },
         {
             "Type": "Script",


### PR DESCRIPTION
Failure in Prepare-AppPackageFolder

Exception setting "ProductVersion": "The property 'ProductVersion' cannot be found on this object. Verify that the 
property exists and can be set."
At C:\ADOAgent\_work\1\s\Scripts\Prepare-AppPackageFolder.ps1:145 char:41
+ ...                   $DetectionRuleItem.ProductVersion = $ProductVersion
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : ExceptionWhenSetting
 
##[error]PowerShell exited with code '1'.
