### PR TITLE
Several new features

### DIFF
--- a/Scripts/Install-Modules.ps1
+++ b/Scripts/Install-Modules.ps1
@@ -23,7 +23,7 @@ Process {
     # Ensure package provider is installed
     $PackageProvider = Install-PackageProvider -Name "NuGet" -Force
 
-    $Modules = @("Evergreen", "IntuneWin32App", "Az.Storage", "Az.Resources", "MSGraphRequest")
+    $Modules = @("Evergreen", "IntuneWin32App", "Az.Storage", "Az.Resources")
     foreach ($Module in $Modules) {
         try {
             Write-Output -InputObject "Attempting to locate module: $($Module)"
@@ -46,7 +46,7 @@ Process {
             }
             else {
                 Write-Output -InputObject "Attempting to install module: $($Module)"
-                $InstallModuleInvocation = Install-Module -Name $Module -Force -AllowClobber -ErrorAction "Stop" -Confirm:$false -Verbose:$false
+                $InstallModuleInvocation = Install-Module -Name $Module -Force -ErrorAction "Stop" -Confirm:$false -Verbose:$false
                 Write-Output -InputObject "Module $($Module) installed successfully"
             }
         }

--- a/Scripts/New-Win32App.ps1
+++ b/Scripts/New-Win32App.ps1
@@ -22,23 +22,31 @@
 #>
 [CmdletBinding(SupportsShouldProcess = $true)]
 param (
-    [parameter(Mandatory = $true)]
+    [parameter(Mandatory = $true, ParameterSetName = "ClientSecret")]
+    [parameter(Mandatory = $true, ParameterSetName = "ClientCertificate")]
     [ValidateNotNullOrEmpty()]
     [string]$TenantID,
 
-    [parameter(Mandatory = $true)]
+    [parameter(Mandatory = $true, ParameterSetName = "ClientSecret")]
+    [parameter(Mandatory = $true, ParameterSetName = "ClientCertificate")]
     [ValidateNotNullOrEmpty()]
     [string]$ClientID,
 
-    [parameter(Mandatory = $true)]
+    [parameter(Mandatory = $true, ParameterSetName = "ClientSecret")]
     [ValidateNotNullOrEmpty()]
     [string]$ClientSecret,
 
-    [parameter(Mandatory = $true)]
+    [parameter(Mandatory = $true, ParameterSetName = "ClientCertificate")]
+    [ValidateNotNullOrEmpty()]
+    [System.Security.Cryptography.X509Certificates.X509Certificate2]$ClientCertificate,
+
+    [parameter(Mandatory = $true, ParameterSetName = "ClientSecret")]
+    [parameter(Mandatory = $true, ParameterSetName = "ClientCertificate")]
     [ValidateNotNullOrEmpty()]
     [string]$WorkspaceID,
 
-    [parameter(Mandatory = $true)]
+    [parameter(Mandatory = $true, ParameterSetName = "ClientSecret")]
+    [parameter(Mandatory = $true, ParameterSetName = "ClientCertificate")]
     [ValidateNotNullOrEmpty()]
     [string]$SharedKey
 )
@@ -150,8 +158,15 @@ Process {
     $AppsPublishListFileName = "AppsPublishList.json"
     $AppsPublishListFilePath = Join-Path -Path (Join-Path -Path $env:BUILD_ARTIFACTSTAGINGDIRECTORY -ChildPath "AppsPublishList") -ChildPath $AppsPublishListFileName
 
-    # Retrieve authentication token using client secret from key vault
-    $AuthToken = Connect-MSIntuneGraph -TenantID $TenantID -ClientID $ClientID -ClientSecret $ClientSecret -ErrorAction "Stop"
+    # Retrieve authentication token using client secret from key vault or client certificate
+    switch ($PSCmdlet.ParameterSetName) {
+        "ClientSecret" {
+            $AuthToken = Connect-MSIntuneGraph -TenantID $TenantID -ClientID $ClientID -ClientSecret $ClientSecret -ErrorAction "Stop"
+        }
+        "ClientCertificate" {
+            $AuthToken = Connect-MSIntuneGraph -TenantID $TenantID -ClientID $ClientID -ClientCert $ClientCertificate -ErrorAction "Stop"
+        }
+    }
 
     if (Test-Path -Path $AppsPublishListFilePath) {
         # Read content from AppsPublishList.json file and convert from JSON format

--- a/Scripts/Prepare-AppPackageFolder.ps1
+++ b/Scripts/Prepare-AppPackageFolder.ps1
@@ -61,14 +61,14 @@ Process {
             Copy-Item -Path "$($FrameworkPath)\*" -Destination $AppPublishFolderPath -Recurse -Force -Confirm:$false
 
             # Create Files folder in Source folder if not found
-            $AppsPublishSourceFilesPath = Join-Path -Path $AppsPublishRootPath -ChildPath "$($App.AppFolderName)\Source\Files"
-            if (-not(Test-Path -Path $AppsPublishSourceFilesPath)) {
-                New-Item -Path $AppsPublishSourceFilesPath -ItemType "Directory" -Force -Confirm:$false | Out-Null
+            $AppPublishSourceFilesPath = Join-Path -Path $AppPublishFolderPath -ChildPath "Source\Files"
+            if (-not(Test-Path -Path $AppPublishSourceFilesPath)) {
+                New-Item -Path $AppPublishSourceFilesPath -ItemType "Directory" -Force -Confirm:$false | Out-Null
             }
 
             # Copy app specific installer from downloaded app package path to publish folder
             $AppInstallerPath = Join-Path -Path $App.AppSetupFolderPath -ChildPath $App.AppSetupFileName
-            $AppInstallerDestinationPath = Join-Path -Path $AppPublishFolderPath -ChildPath "Source\Files\$($App.AppSetupFileName)"
+            $AppInstallerDestinationPath = Join-Path -Path $AppPublishSourceFilesPath -ChildPath $App.AppSetupFileName
             Write-Output -InputObject "Copying installer file from app package download folder"
             Write-Output -InputObject "Source path: $($AppInstallerPath)"
             Write-Output -InputObject "Destination path: $($AppInstallerDestinationPath)"

--- a/Scripts/Prepare-AppPackageFolder.ps1
+++ b/Scripts/Prepare-AppPackageFolder.ps1
@@ -76,6 +76,13 @@ Process {
 
             # Copy all required app specific files from app package folder in Apps root folder to publish folder
             $AppPackageFolderPath = Join-Path -Path $SourceDirectory -ChildPath "Apps\$($App.AppFolderName)"
+
+            # Copy SupportFiles folder from app package folder in Apps root to Source folder if it exists and is not empty
+            $AppSupportFilesPath = Join-Path -Path $AppPackageFolderPath -ChildPath "SupportFiles"
+            if (Test-Path -Path "$AppSupportFilesPath\*") {
+                Copy-Item -Path $AppSupportFilesPath -Destination "$AppPublishFolderPath\Source" -Container -Recurse -Force -Confirm:$false
+            }
+
             $AppFileNames = $AppFileNames = @("App.json", "Deploy-Application.ps1", "Icon.png")
             foreach ($AppFileName in $AppFileNames) {
                 Write-Output -InputObject "[FILE: $($AppFileName)] - Processing"

--- a/Scripts/Prepare-AppPackageFolder.ps1
+++ b/Scripts/Prepare-AppPackageFolder.ps1
@@ -153,6 +153,12 @@ Process {
                         Write-Output -InputObject "File path: $($AppFilePath)"
                         $AppFileContent = Get-Content -Path $AppFilePath | ConvertFrom-Json
                         
+                        # Add timestamp to Notes property
+                        if ($AppFileContent.Information.Notes -match "(\#{3})DATETIME(\#{3})") {
+                            Write-Output -InputObject "Setting Notes timestamp to: $(Get-Date -Format yyyy-MM-dd)"
+                            $AppFileContent.Information.Notes = $AppFileContent.Information.Notes -replace "###DATETIME###", (Get-Date -Format yyyy-MM-dd)
+                        }
+
                         # Update version specific property values
                         $AppFileContent.Information.DisplayName = $App.IntuneAppName
                         $AppFileContent.Information.AppVersion = $App.AppSetupVersion

--- a/Scripts/Prepare-AppPackageFolder.ps1
+++ b/Scripts/Prepare-AppPackageFolder.ps1
@@ -102,7 +102,25 @@ Process {
                         Write-Output -InputObject "Setting timestamp to: $((Get-Date).ToShortDateString())"
                         $AppFileContent = $AppFileContent -replace "###DATETIME###", (Get-Date).ToShortDateString()
                         Write-Output -InputObject "Setting setup file name to: $($App.AppSetupFileName)"
-                        $AppFileContent = $AppFileContent -replace "###SETUPFILENAME###", $($App.AppSetupFileName)
+                        $AppFileContent = $AppFileContent -replace "###SETUPFILENAME###", $App.AppSetupFileName
+                        Write-Output -InputObject "Setting PSADT pre-install section to: $($AppData.PSADT.PreInstallSection)"
+                        $AppFileContent = $AppFileContent -replace "###PREINSTALLSECTION###", $AppData.PSADT.PreInstallSection
+                        Write-Output -InputObject "Setting PSADT install section to: $($AppData.PSADT.InstallSection)"
+                        $AppFileContent = $AppFileContent -replace "###INSTALLSECTION###", $AppData.PSADT.InstallSection
+                        Write-Output -InputObject "Setting PSADT post-install section to: $($AppData.PSADT.PostInstallSection)"
+                        $AppFileContent = $AppFileContent -replace "###POSTINSTALLSECTION###", $AppData.PSADT.PostInstallSection
+                        Write-Output -InputObject "Setting PSADT pre-uninstall section to: $($AppData.PSADT.PreUninstallSection)"
+                        $AppFileContent = $AppFileContent -replace "###PREUNINSTALLSECTION###", $AppData.PSADT.PreUninstallSection
+                        Write-Output -InputObject "Setting PSADT uninstall section to: $($AppData.PSADT.UninstallSection)"
+                        $AppFileContent = $AppFileContent -replace "###UNINSTALLSECTION###", $AppData.PSADT.UninstallSection
+                        Write-Output -InputObject "Setting PSADT post-uninstall section to: $($AppData.PSADT.PostUninstallSection)"
+                        $AppFileContent = $AppFileContent -replace "###POSTUNINSTALLSECTION###", $AppData.PSADT.PostUninstallSection
+                        Write-Output -InputObject "Setting PSADT pre-repair section to: $($AppData.PSADT.PreRepairSection)"
+                        $AppFileContent = $AppFileContent -replace "###PREREPAIRSECTION###", $AppData.PSADT.PreRepairSection
+                        Write-Output -InputObject "Setting PSADT repair section to: $($AppData.PSADT.RepairSection)"
+                        $AppFileContent = $AppFileContent -replace "###REPAIRSECTION###", $AppData.PSADT.RepairSection
+                        Write-Output -InputObject "Setting PSADT post-repair section to: $($AppData.PSADT.PostRepairSection)"
+                        $AppFileContent = $AppFileContent -replace "###POSTREPAIRSECTION###", $AppData.PSADT.PostRepairSection
 
                         # Read and update hardcoded variables with specific MSI data from setup file if file extension is MSI
                         $SetupFileNameExtension = [System.IO.Path]::GetExtension($App.AppSetupFileName).Trim(".")

--- a/Scripts/Test-AppFiles.ps1
+++ b/Scripts/Test-AppFiles.ps1
@@ -101,26 +101,28 @@ Process {
                                         }
                                     }
                                     else {
-                                        Write-Warning -Message "Icon URL was defined but value was empty, checking for local Icon.png file"
-                                        $IconFilePath = Join-Path -Path $AppPackageFolderPath -ChildPath "Icon.png"
+                                        $IconFile = $AppFileContent.PackageInformation.IconFile
+                                        Write-Warning -Message "Icon URL was defined but value was empty, checking for local $IconFile file"
+                                        $IconFilePath = Join-Path -Path $AppPackageFolderPath -ChildPath $IconFile
                                         if (-not(Test-Path -Path $IconFilePath)) {
-                                            Write-Warning -Message "Could not detect local Icon.png file in app folder"
+                                            Write-Warning -Message "Could not detect local $IconFile file in app folder"
                                             $AppAllowed = $false
                                         }
                                         else {
-                                            Write-Output -InputObject "Found local Icon.png file in app folder"
+                                            Write-Output -InputObject "Found local $IconFile file in app folder"
                                         }
                                     }
                                 }
                                 else {
-                                    Write-Output -InputObject "Icon URL was not defined, testing for local Icon.png file"
-                                    $IconFilePath = Join-Path -Path $AppPackageFolderPath -ChildPath "Icon.png"
+                                    $IconFile = $AppFileContent.PackageInformation.IconFile
+                                    Write-Output -InputObject "Icon URL was not defined, testing for local $IconFile file"
+                                    $IconFilePath = Join-Path -Path $AppPackageFolderPath -ChildPath $IconFile
                                     if (-not(Test-Path -Path $IconFilePath)) {
-                                        Write-Warning -Message "Could not detect local Icon.png file in app folder"
+                                        Write-Warning -Message "Could not detect local $IconFile file in app folder"
                                         $AppAllowed = $false
                                     }
                                     else {
-                                        Write-Output -InputObject "Found local Icon.png file in app folder"
+                                        Write-Output -InputObject "Found local $IconFile file in app folder"
                                     }
                                 }
         

--- a/Scripts/Test-AppFiles.ps1
+++ b/Scripts/Test-AppFiles.ps1
@@ -168,6 +168,7 @@ Process {
                     "AppSource" = $App.AppSource
                     "AppId" = if (-not([string]::IsNullOrEmpty($App.AppId))) { $App.AppId } else { [string]::Empty }
                     "AppFolderName" = $App.AppFolderName
+                    "AppSetupFileName" = $App.AppSetupFileName
                     "FilterOptions" =  $App.FilterOptions
                     "StorageAccountName" = if (-not([string]::IsNullOrEmpty($App.StorageAccountName))) { $App.StorageAccountName } else { [string]::Empty }
                     "StorageAccountContainerName" = if (-not([string]::IsNullOrEmpty($App.StorageAccountContainerName))) { $App.StorageAccountContainerName } else { [string]::Empty }

--- a/Scripts/Test-AppList.ps1
+++ b/Scripts/Test-AppList.ps1
@@ -26,19 +26,26 @@
 #>
 [CmdletBinding(SupportsShouldProcess = $true)]
 param (
-    [parameter(Mandatory = $true)]
+    [parameter(Mandatory = $true, ParameterSetName = "ClientSecret")]
+    [parameter(Mandatory = $true, ParameterSetName = "ClientCertificate")]
     [ValidateNotNullOrEmpty()]
     [string]$TenantID,
 
-    [parameter(Mandatory = $true)]
+    [parameter(Mandatory = $true, ParameterSetName = "ClientSecret")]
+    [parameter(Mandatory = $true, ParameterSetName = "ClientCertificate")]
     [ValidateNotNullOrEmpty()]
     [string]$ClientID,
 
-    [parameter(Mandatory = $true)]
+    [parameter(Mandatory = $true, ParameterSetName = "ClientSecret")]
     [ValidateNotNullOrEmpty()]
     [string]$ClientSecret,
 
-    [parameter(Mandatory = $true)]
+    [parameter(Mandatory = $true, ParameterSetName = "ClientCertificate")]
+    [ValidateNotNullOrEmpty()]
+    [System.Security.Cryptography.X509Certificates.X509Certificate2]$ClientCertificate,
+
+    [parameter(Mandatory = $true, ParameterSetName = "ClientSecret")]
+    [parameter(Mandatory = $true, ParameterSetName = "ClientCertificate")]
     [ValidateNotNullOrEmpty()]
     [string]$StorageAccountAccessKey
 )
@@ -285,8 +292,15 @@ Process {
     $SourceDirectory = $env:BUILD_SOURCESDIRECTORY
 
     try {
-        # Authenticate with MS Graph using client secret from key vault
-        Connect-MSIntuneGraph -TenantID $TenantID -ClientID $ClientID -ClientSecret $ClientSecret -ErrorAction "Stop" | Out-Null
+        # Authenticate with MS Graph using client secret from key vault or client certificate
+        switch ($PSCmdlet.ParameterSetName) {
+            "ClientSecret" {
+                Connect-MSIntuneGraph -TenantID $TenantID -ClientID $ClientID -ClientSecret $ClientSecret -ErrorAction "Stop" | Out-Null
+            }
+            "ClientCertificate" {
+                Connect-MSIntuneGraph -TenantID $TenantID -ClientID $ClientID -ClientCert $ClientCertificate -ErrorAction "Stop" | Out-Null
+            }
+        }
 
         # Construct list of applications to be processed in the next stage
         $AppsDownloadList = New-Object -TypeName "System.Collections.ArrayList"

--- a/Scripts/Test-AppList.ps1
+++ b/Scripts/Test-AppList.ps1
@@ -285,8 +285,8 @@ Process {
     $SourceDirectory = $env:BUILD_SOURCESDIRECTORY
 
     try {
-        # Retrieve authentication token using client secret from key vault
-        $AuthToken = Get-AccessToken -TenantID $TenantID -ClientID $ClientID -ClientSecret $ClientSecret -ErrorAction "Stop"
+        # Authenticate with MS Graph using client secret from key vault
+        Connect-MSIntuneGraph -TenantID $TenantID -ClientID $ClientID -ClientSecret $ClientSecret -ErrorAction "Stop" | Out-Null
 
         # Construct list of applications to be processed in the next stage
         $AppsDownloadList = New-Object -TypeName "System.Collections.ArrayList"
@@ -365,64 +365,53 @@ Process {
                                 }
                             }
                             
-                            # Attempt to locate the application in Intune
+                            # Attempt to locate the application in Intune matching DisplayName
                             Write-Output -InputObject "Attempting to find application in Intune using naming convention: $($AppDisplayName)"
-                            $Win32AppResources = Invoke-MSGraphOperation -Get -APIVersion "Beta" -Resource "deviceAppManagement/mobileApps?`$filter=isof('microsoft.graph.win32LobApp')"
-                            if ($Win32AppResources -ne $null) {
-
-                                # Detect Win32 application matching displayName
-                                $Win32Apps = $Win32AppResources | Where-Object { $PSItem.displayName -like "$($AppDisplayName)*" }
-                                if ($Win32Apps -ne $null) {
-                                    $Win32AppsCount = ($Win32Apps | Measure-Object).Count
-                                    Write-Output -InputObject "Count of detected Intune Win32 applications: $($Win32AppsCount)"
-                                }
-                                else {
-                                    Write-Output -InputObject "Application with defined name '$($AppDisplayName)' was not found, adding to download list"
-    
-                                    # Mark new application to be published
-                                    $AppDownload = $true
-                                }
-    
-                                # Filter for the latest version published in Intune, if multiple applications objects was detected
-                                $Win32AppLatestPublishedVersion = $Win32Apps.displayVersion | Where-Object { $PSItem -as [System.Version] } | Sort-Object { [System.Version]$PSItem } -Descending | Select-Object -First 1
-    
-                                # Version validation and conversion if necessary
-                                if (Test-Version -Version $AppItem.Version) {
-                                    Write-Output -InputObject "Version string is valid"
-                                }
-                                else {
-                                    Write-Output -InputObject "Version string contains invalid characters, attempting to convert"
-                                    $AppItem.Version = ConvertTo-Version -Version $AppItem.Version
-                                    Write-Output -InputObject "Converted version string: $($AppItem.Version)"
-                                }
-
-                                # Perform version comparison check
-                                Write-Output -InputObject "Performing version comparison check to determine if a newer version of the application exists"
-                                if ([System.Version]$AppItem.Version -gt [System.Version]$Win32AppLatestPublishedVersion) {
-                                    # Determine value for published version if not found
-                                    if ($Win32AppLatestPublishedVersion -eq $null) {
-                                        $Win32AppLatestPublishedVersion = "Not found"
-                                    }
-
-                                    Write-Output -InputObject "Newer version exists for application, version details:"
-                                    Write-Output -InputObject "Latest version: $($AppItem.Version)"
-                                    Write-Output -InputObject "Published version: $($Win32AppLatestPublishedVersion)"
-                                    Write-Output -InputObject "Adding application to download list"
-                                    
-                                    # Mark new application version to be published
-                                    $AppDownload = $true
-                                }
-                                else {
-                                    Write-Output -InputObject "Latest version of application is already published"
-                                }
+                            $Win32Apps = Get-IntuneWin32App -DisplayName $AppDisplayName
+                            if ($Win32Apps -ne $null) {
+                                $Win32AppsCount = ($Win32Apps | Measure-Object).Count
+                                Write-Output -InputObject "Count of detected Intune Win32 applications: $($Win32AppsCount)"
                             }
                             else {
-                                Write-Warning -Message "Unhandled error occurred, application will be skipped"
-    
-                                # Handle current application output completed message
-                                Write-Output -InputObject "[APPLICATION: $($App.IntuneAppName)] - Skipped"
+                                Write-Output -InputObject "Application with defined name '$($AppDisplayName)' was not found, adding to download list"
+
+                                # Mark new application to be published
+                                $AppDownload = $true
                             }
-    
+
+                            # Filter for the latest version published in Intune, if multiple applications objects was detected
+                            $Win32AppLatestPublishedVersion = $Win32Apps.displayVersion | Where-Object { $PSItem -as [System.Version] } | Sort-Object { [System.Version]$PSItem } -Descending | Select-Object -First 1
+
+                            # Version validation and conversion if necessary
+                            if (Test-Version -Version $AppItem.Version) {
+                                Write-Output -InputObject "Version string is valid"
+                            }
+                            else {
+                                Write-Output -InputObject "Version string contains invalid characters, attempting to convert"
+                                $AppItem.Version = ConvertTo-Version -Version $AppItem.Version
+                                Write-Output -InputObject "Converted version string: $($AppItem.Version)"
+                            }
+
+                            # Perform version comparison check
+                            Write-Output -InputObject "Performing version comparison check to determine if a newer version of the application exists"
+                            if ([System.Version]$AppItem.Version -gt [System.Version]$Win32AppLatestPublishedVersion) {
+                                # Determine value for published version if not found
+                                if ($Win32AppLatestPublishedVersion -eq $null) {
+                                    $Win32AppLatestPublishedVersion = "Not found"
+                                }
+
+                                Write-Output -InputObject "Newer version exists for application, version details:"
+                                Write-Output -InputObject "Latest version: $($AppItem.Version)"
+                                Write-Output -InputObject "Published version: $($Win32AppLatestPublishedVersion)"
+                                Write-Output -InputObject "Adding application to download list"
+                                
+                                # Mark new application version to be published
+                                $AppDownload = $true
+                            }
+                            else {
+                                Write-Output -InputObject "Latest version of application is already published"
+                            }
+
                             # Add current app to list if publishing is required
                             if ($AppDownload -eq $true) {
                                 # Construct new application custom object with required properties

--- a/Scripts/Test-AppList.ps1
+++ b/Scripts/Test-AppList.ps1
@@ -355,8 +355,12 @@ Process {
                     Write-Output -InputObject "URI: $($AppItem.URI)"
 
                     try {
-                        # Attempt to deserialize the setup file name from the URI
-                        $AppSetupFileName = [Uri]$AppItem.URI | Select-Object -ExpandProperty "Segments" | Select-Object -Last 1
+                        # Determine app setup file name
+                        $AppSetupFileName = $App.AppSetupFileName
+                        if ([string]::IsNullOrEmpty($AppSetupFileName)) {
+                            # Attempt to deserialize the setup file name from the URI
+                            $AppSetupFileName = [Uri]$AppItem.URI | Select-Object -ExpandProperty "Segments" | Select-Object -Last 1
+                        }
                         Write-Output -InputObject "Setup file name: $($AppSetupFileName)"
 
                         try {

--- a/Templates/Application/App.json
+++ b/Templates/Application/App.json
@@ -23,6 +23,17 @@
         "DeviceRestartBehavior": "<<SELECT_VALUE:[suppress, force, basedOnReturnCode, allow]>>",
         "AllowAvailableUninstall": "<<SELECT_VALUE:[true, false]>>"
     },
+    "PSADT": {
+        "PreInstallSection": "",
+        "InstallSection": "<<ENTER_VALUE>>",
+        "PostInstallSection": "",
+        "PreUninstallSection": "",
+        "UninstallSection": "<<ENTER_VALUE>>",
+        "PostUninstallSection": "",
+        "PreRepairSection": "",
+        "RepairSection": "",
+        "PostRepairSection": ""
+    },
     "RequirementRule": {
         "MinimumSupportedWindowsRelease": "<<SELECT_VALUE:[W10_1607, W10_1703, W10_1709, W10_1809, W10_1909, W10_2004, W10_20H2, W10_21H1, W10_21H2, W10_22H2, W11_21H2, W11_22H2]>>",
         "Architecture": "<<SELECT_VALUE:[All, x64, x86]>>"

--- a/Templates/Application/App.json
+++ b/Templates/Application/App.json
@@ -12,7 +12,7 @@
         "AppVersion": "<replaced_by_pipeline>",
         "Description": "<<ENTER_VALUE:[custom_text]>>",
         "Publisher": "<replaced_by_pipeline>",
-        "Notes": "<<ENTER_VALUE:[custom_text]>>",
+        "Notes": "Created by IntuneAppFactory on ###DATETIME###",
         "Owner": "<<ENTER_VALUE:[custom_text]>>",
         "ScopeTagName": "<<ENTER_VALUE:[custom_text]>>"
     },

--- a/Templates/Application/Deploy-Application.ps1
+++ b/Templates/Application/Deploy-Application.ps1
@@ -126,6 +126,7 @@ Try {
 		#Show-InstallationProgress
 		
 		## <Perform Pre-Installation tasks here>
+		###PREINSTALLSECTION###
 
 		## SAMPLE: Uninstall any previous versions of application by calling the command from Uninstall-string
 		#Remove-MSIApplications -Name "<App_Display_Name>"
@@ -145,6 +146,7 @@ Try {
 		}
 		
 		## ***********************<PERFORM INSTALLATION TASK HERE>********************
+		###INSTALLSECTION###
 
 		## SAMPLE: EXE
 		#$exeInstall = "###SETUPFILENAME###"
@@ -183,6 +185,7 @@ Try {
 		[string]$installPhase = 'Post-Installation'
 		
 		## <Perform Post-Installation tasks here>
+		###POSTINSTALLSECTION###
 		
 		## Display a message at the end of the install
 		#If (-not $useDefaultMsi) { Show-InstallationPrompt -Message 'You can customize text to appear at the end of an install or remove it completely for unattended installations.' -ButtonRightText 'OK' -Icon Information -NoWait }
@@ -201,6 +204,7 @@ Try {
 		#Show-InstallationProgress
 		
 		## <Perform Pre-Uninstallation tasks here>
+		###PREUNINSTALLSECTION###
 		
 		##*===============================================
 		##* UNINSTALLATION
@@ -214,6 +218,7 @@ Try {
 		}
 		
 		# ***********************<PERFORM UN-INSTALLATION TASK HERE>********************
+		###UNINSTALLSECTION###
 
 		## SAMPLE: Uninstall any previous versions of application by calling the command from Uninstall-string
 		#Remove-MSIApplications -Name "<App_Display_Name>"
@@ -227,6 +232,7 @@ Try {
 		[string]$installPhase = 'Post-Uninstallation'
 		
 		## <Perform Post-Uninstallation tasks here>
+		###POSTUNINSTALLSECTION###
 
 	}
 	


### PR DESCRIPTION
Would love to contribute to this awesome project with several new features that I developed for my company needs:

1. Got rid of MSGraphRequest module dependency. The only place where it's used is to query Win32 apps here, where it can be substituted with IntuneWin32App's `Get-IntuneWin32App` which does exactly the same:
https://github.com/MSEndpointMgr/IntuneAppFactory/blob/632e04311326fffae1c1b75f26f994b9ca2fb5c9/Scripts/Test-AppList.ps1#L370

2. Certificate authentication to MS Graph, since `Connect-MSIntuneGraph` does support it.
3. Full PSADT Deploy-Application.ps1 script creation automation. No need to pre-create it - just add respective command lines to App.json.
@NickolajA  your PSADT framework version is begging to be updated, I wasn't even able to add support for Repair cmd lines.

4. Copying of PSADT SupportFiles folder from app source into the package.
5. Add into the Intune app Notes for each new app: "Created by IntuneAppFactory on ###DATETIME###"
6. Custom app icon file name (and file extension). Static name of Icon.png just wasn't good enough for me. Ideally file extension validation needs to be added as well.
7. Custom setup file name. The latest improvement of making the setup file name dynamic didn't go well with me - I like the executable name to always be the same, therefore I reintroduced this possibility.

8. I have also adapted Intune App Factory to run on Github, but it's a bit complicated to share since I just changed all Azure Devops references in the code to Github Actions. If you wanted to support both at the same time, then some kind of different approach would have to be applied. I'll probably just share my version of Github workflow separately.