### PR TITLE
New Feature: custom user agent

### DIFF
--- a/Scripts/Install-Modules.ps1
+++ b/Scripts/Install-Modules.ps1
@@ -18,12 +18,13 @@
     Version history:
     1.0.0 - (2022-04-04) Script created
     1.0.1 - (2024-03-04) Improved module installation logic
+    1.0.2 - (2024-11-22) Added Nevergreen Module
 #>
 Process {
     # Ensure package provider is installed
     $PackageProvider = Install-PackageProvider -Name "NuGet" -Force
 
-    $Modules = @("Evergreen", "IntuneWin32App", "Az.Storage", "Az.Resources", "MSGraphRequest")
+    $Modules = @("Evergreen", "Nevergreen", "IntuneWin32App", "Az.Storage", "Az.Resources", "MSGraphRequest")
     foreach ($Module in $Modules) {
         try {
             Write-Output -InputObject "Attempting to locate module: $($Module)"

--- a/Scripts/Save-Installer.ps1
+++ b/Scripts/Save-Installer.ps1
@@ -13,12 +13,13 @@
     Author:      Nickolaj Andersen
     Contact:     @NickolajA
     Created:     2022-04-04
-    Updated:     2024-03-04
+    Updated:     2025-01-02
 
     Version history:
     1.0.0 - (2022-04-04) Script created
     1.0.1 - (2023-06-14) Added support for download setup files from storage account
     1.0.2 - (2024-03-04) Added support for decompressing downloaded setup archive files and finding setup file within archive
+    1.0.3 - (2025-01-02) Added custom UserAgent to fix some download issues if "wget" is blocked by download provider.
 #>
 [CmdletBinding(SupportsShouldProcess = $true)]
 param (
@@ -40,7 +41,11 @@ Process {
 
             [parameter(Mandatory = $true, HelpMessage = "Specify the output file name of downloaded file.")]
             [ValidateNotNullOrEmpty()]
-            [string]$Name
+            [string]$Name,
+
+            [parameter(Mandatory = $false, HelpMessage = "Specify the UserAgent for the download command if wget is not working.")]
+            [ValidateNotNullOrEmpty()]
+            [string]$UserAgent = "wget"
         )
         Begin {
             # Force usage of TLS 1.2 connection
@@ -71,7 +76,7 @@ Process {
             do {
                 try {
                     $OutFilePath = Join-Path -Path $Path -ChildPath $Name
-                    Invoke-WebRequest -Uri $URI -OutFile $OutFilePath -UseBasicParsing -UserAgent "wget" -ErrorAction "Stop"
+                    Invoke-WebRequest -Uri $URI -OutFile $OutFilePath -UseBasicParsing -UserAgent $UserAgent -ErrorAction "Stop"
                 }
                 catch [System.Exception] {
                     Write-Warning -Message "Failed to download file from '$($URI)' with error message: $($_.Exception.Message)"
@@ -181,8 +186,8 @@ Process {
                         Get-StorageAccountBlobContent -StorageAccountName $App.StorageAccountName -ContainerName $App.StorageAccountContainerName -BlobName $App.BlobName -Path $AppSetupFolderPath -NewName $App.AppSetupFileName -ErrorAction "Stop"
                     }
                     default {
-                        Write-Output -InputObject "Attempting to download '$($App.AppSetupFileName)' from: $($App.URI)"
-                        Save-File -URI $App.URI -Path $AppSetupFolderPath -Name $App.AppSetupFileName -ErrorAction "Stop"
+                        Write-Output -InputObject "Attempting to download '$($App.AppSetupFileName)' from: $($App.URI) with UserAgent $($App.UserAgent)"
+                        Save-File -URI $App.URI -Path $AppSetupFolderPath -Name $App.AppSetupFileName -UserAgent $App.UserAgent -ErrorAction "Stop"
                     }
                 }
                 Write-Output -InputObject "Successfully downloaded installer"

--- a/Scripts/Test-AppFiles.ps1
+++ b/Scripts/Test-AppFiles.ps1
@@ -13,12 +13,13 @@
     Author:      Nickolaj Andersen
     Contact:     @NickolajA
     Created:     2022-03-29
-    Updated:     2024-03-27
+    Updated:     2025-01-02
 
     Version history:
     1.0.0 - (2022-03-29) Script created
     1.1.0 - (2022-11-16) Added tests for incorrect detection rule logic and detection of given detection rule script file
     1.1.1 - (2024-03-27) Added test for icon URL accessibility
+    1.1.2 - (2025-01-02) Added custom UserAgent to fix some download issues if "wget" is blocked by download provider.
 #>
 Process {
     # Intitialize variables
@@ -170,6 +171,7 @@ Process {
                     "StorageAccountName" = if (-not([string]::IsNullOrEmpty($App.StorageAccountName))) { $App.StorageAccountName } else { [string]::Empty }
                     "StorageAccountContainerName" = if (-not([string]::IsNullOrEmpty($App.StorageAccountContainerName))) { $App.StorageAccountContainerName } else { [string]::Empty }
                     "IconURL" = if ($IconURLAvailable -eq $true) { $AppFileContent.PackageInformation.IconURL } else { [string]::Empty }
+                    "UserAgent" = if (-not([string]::IsNullOrEmpty($App.UserAgent))) { $App.UserAgent } else { "wget" }
                 }
 
                 # Add to list of applications to be processed

--- a/Scripts/Test-AppList.ps1
+++ b/Scripts/Test-AppList.ps1
@@ -24,6 +24,7 @@
     1.0.5 - (2024-08-25) Added function to test and convert version strings with invalid characters to improve version comparison for detected applications in Intune.
                          Improved application detection logic using the new naming convention property specified in the appList.json file.
     1.0.6 - (2024-11-22) Added Nevergreen Appsource
+    1.0.7 - (2025-01-02) Added custom UserAgent to fix some download issues if "wget" is blocked by download provider.
 #>
 [CmdletBinding(SupportsShouldProcess = $true)]
 param (
@@ -523,6 +524,7 @@ Process {
                                     "AppSetupFileName" = $AppSetupFileName
                                     "AppSetupVersion" = $AppItem.Version
                                     "URI" = $AppItem.URI
+                                    "UserAgent" = $App.UserAgent
                                     "InstallerType" = $AppItem.InstallerType
                                     "FileExtension" = $AppItem.FileExtension
                                     "StorageAccountName" = if (-not([string]::IsNullOrEmpty($App.StorageAccountName))) { $App.StorageAccountName } else { [string]::Empty }

--- a/Scripts/Test-AppList.ps1
+++ b/Scripts/Test-AppList.ps1
@@ -124,7 +124,7 @@ Process {
                 $FilterList.Add("`$PSItem.Release -eq ""$($FilterOptions.Release)""") | Out-Null
             }
             if ($FilterOptions.ImageType) {
-                $FilterList.Add("`$PSItem.Release -eq ""$($FilterOptions.Release)""") | Out-Null
+                $FilterList.Add("`$PSItem.ImageType -eq ""$($FilterOptions.Release)""") | Out-Null
             }
 
             # Construct script block from filter list array
@@ -190,7 +190,7 @@ Process {
                 $FilterList.Add("`$PSItem.Release -eq ""$($FilterOptions.Release)""") | Out-Null
             }
             if ($FilterOptions.ImageType) {
-                $FilterList.Add("`$PSItem.Release -eq ""$($FilterOptions.ImageType)""") | Out-Null
+                $FilterList.Add("`$PSItem.ImageType -eq ""$($FilterOptions.ImageType)""") | Out-Null
             }
 
             # Construct script block from filter list array

--- a/Scripts/Test-AppList.ps1
+++ b/Scripts/Test-AppList.ps1
@@ -23,6 +23,7 @@
     1.0.4 - (2024-03-07) Added support for empty filter options in Get-EvergreenAppItem function
     1.0.5 - (2024-08-25) Added function to test and convert version strings with invalid characters to improve version comparison for detected applications in Intune.
                          Improved application detection logic using the new naming convention property specified in the appList.json file.
+    1.0.6 - (2024-11-22) Added Nevergreen Appsource
 #>
 [CmdletBinding(SupportsShouldProcess = $true)]
 param (
@@ -138,6 +139,76 @@ Process {
         
         # Handle return value
         return $EvergreenApp
+    }
+
+    function Get-NevergreenAppItem {
+        param (
+            [parameter(Mandatory = $true)]
+            [ValidateNotNullOrEmpty()]
+            [string]$AppId,
+
+            [Parameter(Mandatory = $false)]
+            [System.Collections.Hashtable] $AppParams,
+    
+            [parameter(Mandatory = $false)]
+            [ValidateNotNullOrEmpty()]
+            [System.Object[]]$FilterOptions
+        )
+        if ($PSBoundParameters["FilterOptions"]) {
+            # Construct array list to build the dynamic filter list
+            $FilterList = New-Object -TypeName "System.Collections.ArrayList"
+                
+            # Process known filter properties and add them to array list if present on current object
+            if ($FilterOptions.Architecture) {
+                $FilterList.Add("`$PSItem.Architecture -eq ""$($FilterOptions.Architecture)""") | Out-Null
+            }
+            if ($FilterOptions.Platform) {
+                $FilterList.Add("`$PSItem.Platform -eq ""$($FilterOptions.Platform)""") | Out-Null
+            }
+            if ($FilterOptions.Channel) {
+                $FilterList.Add("`$PSItem.Channel -eq ""$($FilterOptions.Channel)""") | Out-Null
+            }
+            if ($FilterOptions.Type) {
+                $FilterList.Add("`$PSItem.Type -eq ""$($FilterOptions.Type)""") | Out-Null
+            }
+            if ($FilterOptions.Installer) {
+                $FilterList.Add("`$PSItem.Installer -eq ""$($FilterOptions.Installer)""") | Out-Null
+            }
+            if ($FilterOptions.InstallerType) {
+                $FilterList.Add("`$PSItem.InstallerType -eq ""$($FilterOptions.InstallerType)""") | Out-Null
+            }
+            if ($FilterOptions.Language) {
+                $FilterList.Add("`$PSItem.Language -eq ""$($FilterOptions.Language)""") | Out-Null
+            }
+            if ($FilterOptions.Edition) {
+                $FilterList.Add("`$PSItem.Edition -eq ""$($FilterOptions.Edition )""") | Out-Null
+            }
+            if ($FilterOptions.Ring) {
+                $FilterList.Add("`$PSItem.Ring -eq ""$($FilterOptions.Ring)""") | Out-Null
+            }
+            if ($FilterOptions.Release) {
+                $FilterList.Add("`$PSItem.Release -eq ""$($FilterOptions.Release)""") | Out-Null
+            }
+            if ($FilterOptions.ImageType) {
+                $FilterList.Add("`$PSItem.Release -eq ""$($FilterOptions.ImageType)""") | Out-Null
+            }
+
+            # Construct script block from filter list array
+            $FilterExpression = [scriptblock]::Create(($FilterList -join " -and "))
+
+            # Get the evergreen app based on dynamic filter list
+            If ($null -ne $AppParams){
+                $NevergreenApp = Get-NevergreenApp -Name $AppId -AppParams $AppParams  | Where-Object -FilterScript $FilterExpression
+            } else {
+                $NevergreenApp = Get-NevergreenApp -Name $AppId | Where-Object -FilterScript $FilterExpression
+            }
+        }
+        else {
+            $NevergreenApp = Get-NevergreenApp -Name $AppId
+        }
+        
+        # Handle return value
+        return $NevergreenApp
     }
 
     function Get-WindowsPackageManagerItem {
@@ -326,6 +397,22 @@ Process {
                         else {
                             Write-Output -InputObject "AppId value: $($App.AppId)"
                             $AppItem = Get-EvergreenAppItem -AppId $App.AppId
+                        }
+                    }
+                    "Nevergreen" {
+                        Write-Output -InputObject "Attempting to retrieve app details from Nevergreen"
+                        if ($null -ne $App.FilterOptions) {
+                            Write-Output -InputObject "AppId value: $($App.AppId)"
+                            Write-Output -InputObject "Filter options: $($App.FilterOptions)"
+                            If ($null -ne $App.AppParams.AppLanguage){
+                                $AppItem = Get-NevergreenAppItem -AppId $App.AppId -AppParams @{Language = $App.AppParams.AppLanguage} -FilterOptions $App.FilterOptions 
+                            } else {
+                                $AppItem = Get-NevergreenAppItem -AppId $App.AppId -FilterOptions $App.FilterOptions
+                            } 
+                        }
+                        else {
+                            Write-Output -InputObject "AppId value: $($App.AppId)"
+                            $AppItem = Get-NevergreenAppItem -AppId $App.AppId
                         }
                     }
                     "StorageAccount" {


### PR DESCRIPTION
If downloading fails because the useragent "wget" is blocked by the downloading provider you can now define a custom UserAgent in applist.json for every single app. If UserAgent is not set the intuneappfactory will use the default value "wget".

Example
`
{
    "Apps": [
        {
            "IntuneAppName": "7-Zip",
            "IntuneAppNamingConvention": "AppName",
            "AppPublisher": "Igor Pavlov",
            "AppSource": "Nevergreen",
            "AppID": "7zip",
            "AppFolderName": "7zip",
            "UserAgent": "Powershell",
            "FilterOptions": [
                {
                    "Architecture": "x64",
                    "Type": "msi"
                }
            ]
        }
    ]
}
`